### PR TITLE
Fix Supabase IDs and admin utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The application requires these tables in Supabase:
 - **users_pt2024**: User authentication and profile data
 - **clients_pt2024**: Client information and details
 - **analyses_pt2024**: Financial analysis data
-- **admin_settings_pt2024**: Global admin settings
-- **pending_users_pt2024**: Registrations awaiting approval
+- **admin_settings_pt2024**: Admin settings
+- **pending_users_pt2024**: Pending user registrations
 
 ### 3. Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,23 @@
 The application requires these tables in Supabase:
 
 - **users_pt2024**: User authentication and profile data
-- **clients_pt2024**: Client information and details  
+- **clients_pt2024**: Client information and details
 - **analyses_pt2024**: Financial analysis data
+- **admin_settings_pt2024**: Global admin settings
+- **pending_users_pt2024**: Registrations awaiting approval
 
-### 3. Features
+### 3. Environment Setup
+
+Create a `.env` file in the project root with your Supabase credentials:
+
+```env
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
+These variables are loaded by `src/lib/supabase.js`.
+
+### 4. Features
 
 - ✅ User authentication with Supabase
 - ✅ Client management with full CRUD operations
@@ -31,7 +44,7 @@ The application requires these tables in Supabase:
 - ✅ Life insurance calculator
 - ✅ Debt stacking calculator
 
-### 4. Demo Credentials
+### 5. Demo Credentials
 
 **Admin Account:**
 - Email: sebasrodus+admin@gmail.com  
@@ -41,7 +54,7 @@ The application requires these tables in Supabase:
 - Email: advisor@prospertrack.com
 - Password: advisor123
 
-### 5. Data Persistence
+### 6. Data Persistence
 
 The application now properly saves data to Supabase:
 
@@ -51,14 +64,14 @@ The application now properly saves data to Supabase:
 
 Data is also backed up to localStorage as a fallback mechanism.
 
-### 6. Development
+### 7. Development
 
 ```bash
 npm install
 npm run dev
 ```
 
-### 7. Build
+### 8. Build
 
 ```bash
 npm run build

--- a/database-setup.sql
+++ b/database-setup.sql
@@ -72,6 +72,27 @@ CREATE TABLE analyses_pt2024 (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
+-- Admin settings table
+CREATE TABLE IF NOT EXISTS admin_settings_pt2024 (
+  id SERIAL PRIMARY KEY,
+  auto_approve_registrations BOOLEAN DEFAULT false,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Pending user registrations table
+CREATE TABLE IF NOT EXISTS pending_users_pt2024 (
+  id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+  email VARCHAR(255) NOT NULL,
+  first_name VARCHAR(100) NOT NULL,
+  last_name VARCHAR(100) NOT NULL,
+  role VARCHAR(50) DEFAULT 'financial_professional',
+  company VARCHAR(255),
+  phone VARCHAR(50),
+  bio TEXT,
+  status VARCHAR(20) DEFAULT 'pending',
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
 -- Enable Row Level Security
 ALTER TABLE users_pt2024 ENABLE ROW LEVEL SECURITY;
 ALTER TABLE clients_pt2024 ENABLE ROW LEVEL SECURITY;

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -351,10 +351,11 @@ function AdminDashboard() {
         )}
 
         {/* Always show the Supabase Test Panel for now */}
-<div style={{ position: 'fixed', bottom: '20px', right: '20px', zIndex: 9999 }}>
-  <SupabaseTest />
-</div>
-
+        <div style={{ position: 'fixed', bottom: '20px', right: '20px', zIndex: 9999 }}>
+          <SupabaseTest />
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -26,7 +26,6 @@ function Dashboard() {
 
   const handleAddClient = async (clientData) => {
     const newClient = {
-      id: Date.now().toString(),
       ...clientData,
       userId: user.id, // Associate client with current user
       createdAt: new Date().toISOString()

--- a/src/components/FinancialAnalysis.jsx
+++ b/src/components/FinancialAnalysis.jsx
@@ -169,7 +169,7 @@ function FinancialAnalysis() {
   const saveAnalysis = () => {
     const analysisData = {
       ...analysis,
-      id: analysis.id || Date.now().toString(),
+      id: analysis.id,
       updatedAt: new Date().toISOString()
     };
 

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,8 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
 
-// Project URL and key from environment variables or hardcoded for demo
-const SUPABASE_URL = 'https://clbshhnjniekomqcteum.supabase.co'
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNsYnNoaG5qbmlla29tcWN0ZXVtIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTE1MDkyNjgsImV4cCI6MjA2NzA4NTI2OH0.i84Yfym-6m1S_M1i8VqPiQkzUsQhieoICLoojc2nxDE'
+// Project URL and key loaded from environment variables
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   throw new Error('Missing Supabase credentials');


### PR DESCRIPTION
## Summary
- load Supabase credentials from `.env`
- use UUIDs when creating clients and analyses
- fix closing tags in AdminDashboard
- add admin settings and pending user helpers
- document environment variables
- define DB tables for admin settings and pending users
- document new admin tables

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b8dd9d2808333aada5d194041aec3