### PR TITLE
Connect ClientContext to Supabase

### DIFF
--- a/src/components/ClientProfile.jsx
+++ b/src/components/ClientProfile.jsx
@@ -10,7 +10,7 @@ const { FiArrowLeft, FiEdit2, FiUser, FiMail, FiPhone, FiMapPin, FiCalendar, FiB
 
 function ClientProfile() {
   const { id } = useParams();
-  const { state, dispatch } = useClient();
+  const { state, updateClient } = useClient();
   const [showEditModal, setShowEditModal] = useState(false);
   const [client, setClient] = useState(null);
 
@@ -19,8 +19,8 @@ function ClientProfile() {
     setClient(foundClient);
   }, [id, state.clients]);
 
-  const handleUpdateClient = (updatedClient) => {
-    dispatch({ type: 'UPDATE_CLIENT', payload: { ...updatedClient, id } });
+  const handleUpdateClient = async (updatedClient) => {
+    await updateClient({ ...updatedClient, id });
     setShowEditModal(false);
   };
 

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -11,25 +11,24 @@ import GetStartedModal from './GetStartedModal';
 const { FiPlus, FiUser, FiTrendingUp, FiFileText, FiCalculator, FiCreditCard, FiPlayCircle } = FiIcons;
 
 function Dashboard() {
-  const { state, dispatch } = useClient();
+  const { state, addClient, deleteClient } = useClient();
   const { user, isAdmin } = useAuth();
   const [showClientModal, setShowClientModal] = useState(false);
   const [showGetStarted, setShowGetStarted] = useState(false);
 
-  const handleAddClient = (clientData) => {
+  const handleAddClient = async (clientData) => {
     const newClient = {
-      id: Date.now().toString(),
       ...clientData,
-      userId: user.id, // Associate client with current user
+      userId: user.id,
       createdAt: new Date().toISOString(),
     };
-    dispatch({ type: 'ADD_CLIENT', payload: newClient });
+    await addClient(newClient);
     setShowClientModal(false);
   };
 
-  const handleDeleteClient = (clientId) => {
+  const handleDeleteClient = async (clientId) => {
     if (window.confirm('Are you sure you want to delete this client?')) {
-      dispatch({ type: 'DELETE_CLIENT', payload: clientId });
+      await deleteClient(clientId);
     }
   };
 

--- a/src/components/FinancialAnalysis.jsx
+++ b/src/components/FinancialAnalysis.jsx
@@ -9,7 +9,7 @@ const { FiArrowLeft, FiSave, FiDollarSign, FiUsers, FiHome, FiCreditCard, FiTarg
 
 function FinancialAnalysis() {
   const { id } = useParams();
-  const { state, dispatch } = useClient();
+  const { state, addAnalysis, updateAnalysis } = useClient();
   const [client, setClient] = useState(null);
   const [analysis, setAnalysis] = useState({
     clientId: id,
@@ -166,17 +166,16 @@ function FinancialAnalysis() {
     }));
   };
 
-  const saveAnalysis = () => {
+  const saveAnalysis = async () => {
     const analysisData = {
       ...analysis,
-      id: analysis.id || Date.now().toString(),
       updatedAt: new Date().toISOString()
     };
 
     if (analysis.id) {
-      dispatch({ type: 'UPDATE_ANALYSIS', payload: analysisData });
+      await updateAnalysis(analysisData);
     } else {
-      dispatch({ type: 'ADD_ANALYSIS', payload: analysisData });
+      await addAnalysis({ ...analysisData, clientId: id });
     }
 
     alert('Analysis saved successfully!');

--- a/src/context/ClientContext.jsx
+++ b/src/context/ClientContext.jsx
@@ -1,5 +1,9 @@
 import React, { createContext, useContext, useReducer } from 'react';
 import { useAuth } from './AuthContext';
+import supabaseClient from '../lib/supabase';
+
+const CLIENTS_TABLE = 'client_pt2024';
+const ANALYSES_TABLE = 'analyses_pt2024';
 
 const ClientContext = createContext();
 
@@ -100,6 +104,38 @@ export function ClientProvider({ children }) {
     }
   }, []);
 
+  // Fetch data from Supabase on mount
+  React.useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const { data: clients, error: clientsError } = await supabaseClient
+          .from(CLIENTS_TABLE)
+          .select('*');
+
+        const { data: analyses, error: analysesError } = await supabaseClient
+          .from(ANALYSES_TABLE)
+          .select('*');
+
+        if (clientsError || analysesError) {
+          console.error('Error loading data:', clientsError || analysesError);
+          return;
+        }
+
+        dispatch({
+          type: 'LOAD_DATA',
+          payload: {
+            clients: clients || [],
+            analyses: analyses || []
+          }
+        });
+      } catch (err) {
+        console.error('Error fetching data from Supabase:', err);
+      }
+    };
+
+    fetchData();
+  }, []);
+
   // Save data to localStorage whenever state changes
   React.useEffect(() => {
     safeSetToStorage('financialAnalysisData', state);
@@ -139,10 +175,105 @@ export function ClientProvider({ children }) {
     dispatch(action);
   };
 
+  const addClient = async (clientData) => {
+    try {
+      const { data, error } = await supabaseClient
+        .from(CLIENTS_TABLE)
+        .insert(clientData)
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      enhancedDispatch({ type: 'ADD_CLIENT', payload: data });
+      return data;
+    } catch (err) {
+      console.error('Error adding client:', err);
+      throw err;
+    }
+  };
+
+  const updateClient = async (clientData) => {
+    try {
+      const { data, error } = await supabaseClient
+        .from(CLIENTS_TABLE)
+        .update(clientData)
+        .eq('id', clientData.id)
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      enhancedDispatch({ type: 'UPDATE_CLIENT', payload: data });
+      return data;
+    } catch (err) {
+      console.error('Error updating client:', err);
+      throw err;
+    }
+  };
+
+  const deleteClient = async (clientId) => {
+    try {
+      const { error } = await supabaseClient
+        .from(CLIENTS_TABLE)
+        .delete()
+        .eq('id', clientId);
+
+      if (error) throw error;
+
+      enhancedDispatch({ type: 'DELETE_CLIENT', payload: clientId });
+    } catch (err) {
+      console.error('Error deleting client:', err);
+      throw err;
+    }
+  };
+
+  const addAnalysis = async (analysisData) => {
+    try {
+      const { data, error } = await supabaseClient
+        .from(ANALYSES_TABLE)
+        .insert(analysisData)
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      enhancedDispatch({ type: 'ADD_ANALYSIS', payload: data });
+      return data;
+    } catch (err) {
+      console.error('Error adding analysis:', err);
+      throw err;
+    }
+  };
+
+  const updateAnalysis = async (analysisData) => {
+    try {
+      const { data, error } = await supabaseClient
+        .from(ANALYSES_TABLE)
+        .update(analysisData)
+        .eq('id', analysisData.id)
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      enhancedDispatch({ type: 'UPDATE_ANALYSIS', payload: data });
+      return data;
+    } catch (err) {
+      console.error('Error updating analysis:', err);
+      throw err;
+    }
+  };
+
   return (
-    <ClientContext.Provider value={{ 
-      state: getFilteredState(), 
+    <ClientContext.Provider value={{
+      state: getFilteredState(),
       dispatch: enhancedDispatch,
+      addClient,
+      updateClient,
+      deleteClient,
+      addAnalysis,
+      updateAnalysis,
       rawState: state // For admin access to all data
     }}>
       {children}


### PR DESCRIPTION
## Summary
- wire ClientContext up to Supabase client
- fetch clients and analyses from Supabase tables on provider mount
- add async helper functions to insert, update and delete clients/analyses
- update Dashboard, ClientProfile and FinancialAnalysis to await these methods

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c55d06368833381c174801bc0185a