### PR TITLE
Add RPC for login access

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ VITE_QUEST_TOKEN=your-quest-token
    - Go to your Supabase project dashboard
    - Navigate to "SQL Editor"
    - Create a "New query"
-   - Copy and paste the contents of `database-setup.sql`
-   - Run the query
+  - Copy and paste the contents of `database-setup.sql`
+  - Run the query
+  - The script creates an RPC function `get_user_for_login(email)` which
+    exposes only essential user fields and is callable by anonymous users for
+    login verification.
 
 ## Running the Application
 


### PR DESCRIPTION
## Summary
- allow anonymous users to look up their login row via `get_user_for_login`
- document login RPC in the setup instructions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d1f1125a883338db21914659869a5