### PR TITLE
Add anon grants to DB setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ VITE_QUEST_TOKEN=your-quest-token
 
 1. Create a new Supabase project at [supabase.com](https://supabase.com)
 
-2. Run the database setup script (`database-setup.sql`) in the Supabase SQL editor to create the required tables:
+2. Run the database setup script (`database-setup.sql`) in the Supabase SQL editor to create the required tables. Make sure you execute the updated script so the `anon` role receives the proper schema permissions:
    - Go to your Supabase project dashboard
    - Navigate to "SQL Editor"
    - Create a "New query"

--- a/database-setup.sql
+++ b/database-setup.sql
@@ -303,5 +303,9 @@ AS $$
             created_at;
 $$;
 
--- Allow anonymous execution for sign up
-GRANT EXECUTE ON FUNCTION public.create_user_account(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO anon;
+-- Allow anonymous execution for sign upGRANT EXECUTE ON FUNCTION public.create_user_account(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO anon;
+-- Grant permissions for anon role
+GRANT USAGE ON SCHEMA public TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO anon;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon;
+


### PR DESCRIPTION
## Summary
- grant anon role usage on `public` schema and table privileges
- ensure future tables inherit anon permissions via `ALTER DEFAULT PRIVILEGES`
- document running the updated script in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d51421c5483338426c2b1bc463dc7