### PR TITLE
Fix SQL comment separation

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -303,7 +303,10 @@ AS $$
             created_at;
 $$;
 
--- Allow anonymous execution for sign upGRANT EXECUTE ON FUNCTION public.create_user_account(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT) TO anon;
+-- Allow anonymous execution for sign up
+GRANT EXECUTE ON FUNCTION public.create_user_account(
+  TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO anon;
 -- Grant permissions for anon role
 GRANT USAGE ON SCHEMA public TO anon;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO anon;


### PR DESCRIPTION
## Summary
- separate comment from GRANT statement in `database-setup.sql`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d5ab7be6883339f7ceec7091f9052