### PR TITLE
Integrate Clerk auth middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ PGPORT=5432
 PGUSER=postgres
 PGPASSWORD=password
 PGDATABASE=prospertrack
+
+# Clerk Configuration
+CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
+CLERK_SECRET_KEY=your-clerk-secret-key


### PR DESCRIPTION
## Summary
- add Clerk Express middleware to server
- restrict user, client, and analysis routes using Clerk
- query data using authenticated user id
- document Clerk environment variables

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686dec05a308833385fdb31ba4f07a3a