### PR TITLE
Support connection string config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ VITE_QUEST_USER_ID=your-quest-user-id
 VITE_QUEST_TOKEN=your-quest-token
 
 # PostgreSQL Configuration
+# You can use NETLIFY_DATABASE_URL or DATABASE_URL as a single connection string
+# instead of the individual PG* settings below
+NETLIFY_DATABASE_URL=
 PGHOST=localhost
 PGPORT=5432
 PGUSER=postgres

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ VITE_QUEST_USER_ID=your-quest-user-id
 VITE_QUEST_TOKEN=your-quest-token
 ```
 
+For database access, you can either set the individual `PGHOST`, `PGPORT`,
+`PGUSER`, `PGPASSWORD` and `PGDATABASE` variables or provide a single
+`NETLIFY_DATABASE_URL` (or `DATABASE_URL`) connection string.
+
 ## Database Setup
 
 1. Provision a Neon PostgreSQL database.

--- a/server.js
+++ b/server.js
@@ -8,13 +8,22 @@ const { Pool } = pkg;
 
 dotenv.config();
 
-const pool = new Pool({
-  host: process.env.PGHOST,
-  port: Number(process.env.PGPORT),
-  user: process.env.PGUSER,
-  password: process.env.PGPASSWORD,
-  database: process.env.PGDATABASE,
-});
+let pool;
+if (process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL) {
+  pool = new Pool({
+    connectionString:
+      process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+} else {
+  pool = new Pool({
+    host: process.env.PGHOST,
+    port: Number(process.env.PGPORT),
+    user: process.env.PGUSER,
+    password: process.env.PGPASSWORD,
+    database: process.env.PGDATABASE,
+  });
+}
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
## Summary
- allow configuring `Pool` via `NETLIFY_DATABASE_URL` or `DATABASE_URL`
- document connection string option in README and `.env.example`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686df88c6ab08333ae19da06c280e033