### PR TITLE
Fix .gitignore formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ dist-ssr
 *.ntvs*
 *.njsproj
 *.sln
-*.sw?# Local environment variables
+*.sw?
+
+# Local environment variables
 .env
+.env.*


### PR DESCRIPTION
## Summary
- fix trailing line in `.gitignore`
- ensure comments are complete and consistent

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686e04d7b560833381ce90ed841f2275