### PR TITLE
Sync Clerk session with AuthContext

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,7 +114,7 @@ function AppContent() {
   }
 
   // Show onboarding if user needs it
-  if (isAuthenticated && needsOnboarding) {
+  if (isAuthenticated() && needsOnboarding) {
     return (
       <React.Suspense fallback={<LoadingScreen />}>
         <QuestOnboarding />
@@ -124,7 +124,7 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {isAuthenticated && <Navbar />}
+      {isAuthenticated() && <Navbar />}
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
@@ -132,18 +132,18 @@ function AppContent() {
       >
         <Routes>
           {/* Public Routes */}
-          <Route path="/login" element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <Login />} />
-          <Route path="/signup" element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <SignUp />} />
-          <Route path="/forgot-password" element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <ForgotPassword />} />
-          <Route path="/reset-password" element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <ResetPassword />} />
-          <Route path="/quest-login" element={isAuthenticated ? (
+          <Route path="/login" element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <Login />} />
+          <Route path="/signup" element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <SignUp />} />
+          <Route path="/forgot-password" element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <ForgotPassword />} />
+          <Route path="/reset-password" element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <ResetPassword />} />
+          <Route path="/quest-login" element={isAuthenticated() ? (
             <Navigate to="/dashboard" replace />
           ) : (
             <React.Suspense fallback={<LoadingScreen />}>
               <QuestLogin />
             </React.Suspense>
           )} />
-          <Route path="/onboarding" element={isAuthenticated ? (
+          <Route path="/onboarding" element={isAuthenticated() ? (
             <React.Suspense fallback={<LoadingScreen />}>
               <QuestOnboarding />
             </React.Suspense>
@@ -161,7 +161,7 @@ function AppContent() {
           <Route path="/debt-stacking" element={<ProtectedRoute><DebtStackingCalculator /></ProtectedRoute>} />
 
           {/* Default redirect */}
-          <Route path="/" element={<Navigate to={isAuthenticated ? "/dashboard" : "/login"} replace />} />
+          <Route path="/" element={<Navigate to={isAuthenticated() ? "/dashboard" : "/login"} replace />} />
           
           {/* Catch-all for unknown routes */}
           <Route path="*" element={

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -4,7 +4,7 @@ import { SignIn } from '@clerk/clerk-react';
 function Login() {
   return (
     <div className="min-h-screen flex items-center justify-center">
-      <SignIn path="/login" routing="hash" />
+      <SignIn path="/login" routing="hash" afterSignInUrl="/dashboard" />
     </div>
   );
 }

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -13,7 +13,7 @@ function ProtectedRoute({ children, adminOnly = false }) {
     );
   }
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated()) {
     return <Navigate to="/login" replace />;
   }
 
@@ -23,5 +23,4 @@ function ProtectedRoute({ children, adminOnly = false }) {
 
   return children;
 }
-
 export default ProtectedRoute;


### PR DESCRIPTION
## Summary
- hook into Clerk to detect the current user
- expose `isAuthenticated`/`isAdmin` helpers from `AuthContext`
- redirect to dashboard after sign in
- update consumers to use the new helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ebfc947b083338338a16d02c75171