### PR TITLE
Add admin and onboarding helpers to auth context

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -21,6 +21,10 @@ export const api = {
   createUser: (data) => request('/users', { method: 'POST', body: JSON.stringify(data) }),
   updateUser: (id, data) => request(`/users/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteUser: (id) => request(`/users/${id}`, { method: 'DELETE' }),
+  sendEmailCode: (email) =>
+    request('/auth/send-code', { method: 'POST', body: JSON.stringify({ email }) }),
+  verifyEmailCode: (email, code) =>
+    request('/auth/verify-code', { method: 'POST', body: JSON.stringify({ email, code }) }),
   getClients: () => request('/clients'),
   createClient: (data) => request('/clients', { method: 'POST', body: JSON.stringify(data) }),
   updateClient: (id, data) => request(`/clients/${id}`, { method: 'PUT', body: JSON.stringify(data) }),


### PR DESCRIPTION
## Summary
- extend `AuthContext` with helpers for admin checks and onboarding
- expose email verification utilities
- surface new context helpers in provider
- add API calls for sending and verifying email codes

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ebfe468ec83338b2e71484aa9ca25