### PR TITLE
Add Clerk authentication token to API calls

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
-import api from '../lib/api';
+import useApi from '../lib/api';
 
 const AuthContext = createContext();
 
@@ -25,6 +25,7 @@ function reducer(state, action) {
 
 export function AuthProvider({ children }) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const api = useApi();
 
   useEffect(() => {
     const saved = localStorage.getItem('currentUser');

--- a/src/context/ClientContext.jsx
+++ b/src/context/ClientContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
 import { useAuth } from './AuthContext';
-import api from '../lib/api';
+import useApi from '../lib/api';
 
 const ClientContext = createContext();
 
@@ -24,6 +24,7 @@ function reducer(state, action) {
 export function ClientProvider({ children }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { user } = useAuth();
+  const api = useApi();
 
   const loadData = async () => {
     dispatch({ type: 'LOADING', payload: true });

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,34 +1,44 @@
+import { useAuth } from '@clerk/clerk-react';
+
 const API_URL = import.meta.env?.VITE_API_URL || '';
 
-async function request(path, options = {}) {
-  const url = `${API_URL}${path}`;
-  const res = await fetch(url, {
-    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
-    ...options,
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(text || res.statusText);
+export function useApi() {
+  const { getToken } = useAuth();
+
+  async function request(path, options = {}) {
+    const url = `${API_URL}${path}`;
+    const token = await getToken();
+    const headers = {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+
+    const res = await fetch(url, { ...options, headers });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(text || res.statusText);
+    }
+    return res.json().catch(() => ({}));
   }
-  return res.json().catch(() => ({}));
+
+  return {
+    login: (email, password) =>
+      request('/auth/login', { method: 'POST', body: JSON.stringify({ email, password }) }),
+    signup: (data) => request('/auth/signup', { method: 'POST', body: JSON.stringify(data) }),
+    getUsers: () => request('/users'),
+    createUser: (data) => request('/users', { method: 'POST', body: JSON.stringify(data) }),
+    updateUser: (id, data) => request(`/users/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+    deleteUser: (id) => request(`/users/${id}`, { method: 'DELETE' }),
+    getClients: () => request('/clients'),
+    createClient: (data) => request('/clients', { method: 'POST', body: JSON.stringify(data) }),
+    updateClient: (id, data) => request(`/clients/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+    deleteClient: (id) => request(`/clients/${id}`, { method: 'DELETE' }),
+    getAnalyses: () => request('/analyses'),
+    createAnalysis: (data) => request('/analyses', { method: 'POST', body: JSON.stringify(data) }),
+    updateAnalysis: (id, data) => request(`/analyses/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+    deleteAnalysis: (id) => request(`/analyses/${id}`, { method: 'DELETE' }),
+  };
 }
 
-export const api = {
-  login: (email, password) =>
-    request('/auth/login', { method: 'POST', body: JSON.stringify({ email, password }) }),
-  signup: (data) => request('/auth/signup', { method: 'POST', body: JSON.stringify(data) }),
-  getUsers: () => request('/users'),
-  createUser: (data) => request('/users', { method: 'POST', body: JSON.stringify(data) }),
-  updateUser: (id, data) => request(`/users/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
-  deleteUser: (id) => request(`/users/${id}`, { method: 'DELETE' }),
-  getClients: () => request('/clients'),
-  createClient: (data) => request('/clients', { method: 'POST', body: JSON.stringify(data) }),
-  updateClient: (id, data) => request(`/clients/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
-  deleteClient: (id) => request(`/clients/${id}`, { method: 'DELETE' }),
-  getAnalyses: () => request('/analyses'),
-  createAnalysis: (data) => request('/analyses', { method: 'POST', body: JSON.stringify(data) }),
-  updateAnalysis: (id, data) => request(`/analyses/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
-  deleteAnalysis: (id) => request(`/analyses/${id}`, { method: 'DELETE' }),
-};
-
-export default api;
+export default useApi;


### PR DESCRIPTION
## Summary
- wrap API utilities in `useApi` hook
- fetch session token from Clerk and send it as `Authorization` header
- use the new hook in Auth and Client contexts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ebff0ec1c8333aac4ffa55296cff8