### PR TITLE
Clean README markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ The frontend is built with React and Vite and styled with Tailwind CSS. Developm
 
 ## Database
 
-codex/update-.env.example-with-placeholders
 Replace the Clerk placeholders with your actual keys. Provide the real
 credentials through environment variables or your deployment settings.
 
@@ -38,9 +37,7 @@ For database access, you can either set the individual `PGHOST`, `PGPORT`,
 `NETLIFY_DATABASE_URL` (or `DATABASE_URL`) connection string.
 
 All persistent data lives in a Neon Postgres instance. Schema and seed data are defined in `migrations/initial.sql`.
-main
 
-codex/keep-initial.sql-as-authoritative-migration
 ## Database Setup
 
 1. Provision a Neon PostgreSQL database.
@@ -53,7 +50,6 @@ This script creates the required tables and seed demo users used by the app.
 ## Running the Application
 
 ## Installation
-main
 
 1. Clone the repository and install dependencies:
    ```bash
@@ -77,9 +73,9 @@ main
    PGUSER=postgres
    PGPASSWORD=password
    PGDATABASE=prospertrack
-   CLERK_PUBLISHABLE_KEY=pk_test_aW1tb3J0YWwtc3RhZy00MC5jbGVyay5hY2NvdW50cy5kZXYk
-   VITE_CLERK_PUBLISHABLE_KEY=pk_test_aW1tb3J0YWwtc3RhZy00MC5jbGVyay5hY2NvdW50cy5kZXYk
-   CLERK_SECRET_KEY=sk_test_UeVliIA2wI0NcdX8f7XqODUGopXhOQFUyfPjeQ73un
+   CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
+   VITE_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
+   CLERK_SECRET_KEY=your-clerk-secret-key
    ```
 3. Provision a Neon Postgres database and run the migration script:
    ```bash
@@ -108,7 +104,6 @@ The optimized output is written to the `dist` directory.
 ## Project Structure
 
 ```
-codex/keep-initial.sql-as-authoritative-migration
 prospertrack/
 ├── public/               # Public assets
 ├── src/
@@ -136,19 +131,3 @@ prospertrack/
 ## License
 This project is proprietary software. All rights reserved.
 
-/               project root
-├── server.js            Express API
-├── migrations/          SQL migration scripts
-├── public/              Static assets
-├── src/                 React source code
-│   ├── components/
-│   ├── common/
-│   ├── context/
-│   ├── lib/
-│   ├── App.jsx
-│   └── main.jsx
-├── index.html
-├── package.json
-└── vite.config.js
-```
-main


### PR DESCRIPTION
## Summary
- remove codex markers and stray text from README
- replace sample Clerk keys with placeholders
- delete duplicate project root section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ed938016083338b8d9009f16c1f6a