### PR TITLE
Add CORS support in Express server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # API Configuration
 VITE_API_URL=http://localhost:3000
+# Comma-separated list of allowed CORS origins (leave empty for all)
+CORS_ORIGIN=http://localhost:5173
 
 # Quest API Configuration
 VITE_QUEST_APIKEY=your-quest-api-key

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@questlabs/react-sdk": "^2.1.9",
         "@react-pdf/renderer": "^3.1.14",
         "bcryptjs": "^3.0.2",
+        "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "dotenv": "^17.1.0",
         "echarts": "^5.5.0",
@@ -3282,6 +3283,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/cosmiconfig": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "server": "node server.js"
   },
   "dependencies": {
-    "@clerk/clerk-sdk-node": "^4.13.23",
     "@clerk/clerk-react": "^4.8.4",
+    "@clerk/clerk-sdk-node": "^4.13.23",
     "@questlabs/react-sdk": "^2.1.9",
     "@react-pdf/renderer": "^3.1.14",
     "bcryptjs": "^3.0.2",
+    "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "dotenv": "^17.1.0",
     "echarts": "^5.5.0",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import dotenv from 'dotenv';
 import pkg from 'pg';
 import bcrypt from 'bcryptjs';
+import cors from 'cors';
 import { ClerkExpressRequireAuth, ClerkExpressWithAuth } from '@clerk/clerk-sdk-node';
 
 const { Pool } = pkg;
@@ -27,6 +28,10 @@ if (process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL) {
 
 const app = express();
 app.use(express.json());
+const allowedOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',').map((o) => o.trim())
+  : undefined;
+app.use(allowedOrigins ? cors({ origin: allowedOrigins }) : cors());
 app.use(ClerkExpressWithAuth());
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- install `cors` dependency
- add optional CORS handling in `server.js`
- document `CORS_ORIGIN` in `.env.example`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_686ed921c67c8333a3957873f3875476