### PR TITLE
Update base API URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # API Configuration
-VITE_API_URL=http://localhost:3000
+VITE_API_URL=https://prospertrack-api.onrender.com
 # Comma-separated list of allowed CORS origins (leave empty for all)
 CORS_ORIGIN=http://localhost:5173
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This script creates the required tables and seed demo users used by the app.
    ```
 2. Create a `.env` file based on `.env.example` and configure the variables:
    ```bash
-   VITE_API_URL=http://localhost:3000
+   VITE_API_URL=https://prospertrack-api.onrender.com
    NETLIFY_DATABASE_URL=
    PGHOST=localhost
    PGPORT=5432

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,6 +1,8 @@
 import { useAuth } from '@clerk/clerk-react';
 
-const API_URL = import.meta.env?.VITE_API_URL || '';
+// Default to the Render-hosted API if no environment variable is provided
+const API_URL =
+  import.meta.env?.VITE_API_URL || 'https://prospertrack-api.onrender.com';
 
 export default function useApi() {
   const { getToken } = useAuth();


### PR DESCRIPTION
## Summary
- default API URL to Render backend
- set env example and README to new API URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686efcffc4a48333b5f83ccacb57bbdf